### PR TITLE
Update for flexibility in coral levels

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -20,6 +20,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.robot.constants.AprilTagLocalizationConstants;
+import frc.robot.constants.CoralLevels;
 import frc.robot.generated.TunerConstants;
 import frc.robot.subsystems.AlgaePivot;
 import frc.robot.subsystems.AlgaeRollers;
@@ -135,7 +136,9 @@ public class RobotContainer {
         .onFalse(m_coralRollers.stopCommand());
     m_coDriverController
         .b()
-        .whileTrue(m_coralRollers.rollOutCommand())
+        .whileTrue(
+            m_coralRollers.rollOutCommand(
+                CoralLevels.L2)) // TODO: This should be coming from a state of selection.
         .onFalse(m_coralRollers.stopCommand());
     m_coralRollers
         .getCoralTrigger()

--- a/src/main/java/frc/robot/constants/CoralLevels.java
+++ b/src/main/java/frc/robot/constants/CoralLevels.java
@@ -1,0 +1,30 @@
+package frc.robot.constants;
+
+import static edu.wpi.first.units.Units.Meters;
+import static edu.wpi.first.units.Units.Revolutions;
+import static edu.wpi.first.units.Units.RevolutionsPerSecond;
+
+import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Distance;
+
+public enum CoralLevels {
+  L1(0.0, 1, -100),
+  L2(1.35009765625, 1, -110),
+  L3(2.8163769531249996, 1, -110),
+  L4(4.975830078125, 1, -110),
+  CORAL_STATION(0.914795, 1, 80);
+
+  // Height of the elevator expressed in Revolutions.
+  public final Angle heightAngle;
+  // Distance for starting the raise of the elevator.
+  public final Distance distance;
+  // Velocity for either intake/outake
+  public final AngularVelocity velocity;
+
+  private CoralLevels(double height, double distance, int revolutionsPerSecond) {
+    this.heightAngle = Revolutions.of(height);
+    this.distance = Meters.of(distance);
+    this.velocity = RevolutionsPerSecond.of(revolutionsPerSecond);
+  }
+}

--- a/src/main/java/frc/robot/constants/ElevatorConstants.java
+++ b/src/main/java/frc/robot/constants/ElevatorConstants.java
@@ -1,30 +1,11 @@
 package frc.robot.constants;
 
-import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Revolutions;
 
 import edu.wpi.first.units.measure.Angle;
-import edu.wpi.first.units.measure.Distance;
 import java.util.function.Supplier;
 
 public class ElevatorConstants {
-  public static enum CoralLevels {
-    L1(0.0, 1),
-    L2(1.35009765625, 1),
-    L3(2.7863769531249996, 1),
-    L4(4.975830078125, 1);
-
-    // Height of the elevator expressed in Revolutions.
-    public final Angle heightAngle;
-    // Distance for starting the raise of the elevator.
-    public final Distance distance;
-
-    private CoralLevels(double height, double distance) {
-      this.heightAngle = Revolutions.of(height);
-      this.distance = Meters.of(distance);
-    }
-  }
-
   public static final int ELEVATOR_MOTOR_PORT = 1;
   public static final double ELEVATOR_SPEED = 0.75;
   public static final double ELEVATOR_MAX_HEIGHT = 2.0; // in meters

--- a/src/main/java/frc/robot/subsystems/CommandFactory.java
+++ b/src/main/java/frc/robot/subsystems/CommandFactory.java
@@ -7,7 +7,7 @@ import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import edu.wpi.first.wpilibj2.command.Subsystem;
-import frc.robot.constants.ElevatorConstants.CoralLevels;
+import frc.robot.constants.CoralLevels;
 import frc.robot.constants.PoseConstants.Pose;
 import java.util.HashSet;
 import java.util.function.BooleanSupplier;
@@ -68,10 +68,10 @@ public class CommandFactory {
   }
 
   public Command driveAndPlaceCoral(Pose reefPose, CoralLevels level) {
-    Command raiseElevator = m_elevator.goToCoralHeightPosition(level);
+    Command raiseElevator = m_elevator.setCoralPosition(level);
     Command driveToReef =
         moveToPositionWithDistance(reefPose::getPose, level.distance, raiseElevator);
-    Command placeCoral = m_coralRollers.rollOutCommand();
+    Command placeCoral = m_coralRollers.rollOutCommand(level);
     Command returnCommand = driveToReef.andThen(placeCoral);
 
     return returnCommand;

--- a/src/main/java/frc/robot/subsystems/CoralRollers.java
+++ b/src/main/java/frc/robot/subsystems/CoralRollers.java
@@ -14,6 +14,7 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.constants.CANConstants;
 import frc.robot.constants.CoralConstants;
+import frc.robot.constants.CoralLevels;
 
 public class CoralRollers extends SubsystemBase {
 
@@ -76,13 +77,13 @@ public class CoralRollers extends SubsystemBase {
         .andThen(stopCommand());
   }
 
-  private void rollOut() {
-    m_coralTalonFXS.setControl(m_VelocityVoltage.withVelocity(CoralConstants.OUTTAKE_SPEED));
+  private void rollOut(CoralLevels level) {
+    m_coralTalonFXS.setControl(m_VelocityVoltage.withVelocity(level.velocity));
   }
 
-  public Command rollOutCommand() {
+  public Command rollOutCommand(CoralLevels level) {
     return run(() -> {
-          rollOut();
+          rollOut(level);
         })
         .onlyWhile(m_hasGamePiece)
         .andThen(stopCommand());


### PR DESCRIPTION
## Description of Changes
Introduce flexibility in defining velocity for a coral level as L1 will have a different output velocity than L4.  Removed duplicated code in the Elevator subsystem and reused logic where could.

## Checklist:
<!--Put an 'x' in all of the boxes to assure following guidance.-->
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have [squashed related commits][1]

[1]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
