### PR TITLE
Add backout upon coral intake and coral placement

### DIFF
--- a/src/main/java/frc/robot/subsystems/CommandFactory.java
+++ b/src/main/java/frc/robot/subsystems/CommandFactory.java
@@ -92,7 +92,10 @@ public class CommandFactory {
         .alongWith(intakeCoral)
         .alongWith(pivotAlgaeRollers)
         .until(m_coralRollers.hasCoral())
-        .andThen(finishIntake);
+        .andThen(finishIntake)
+        .andThen(
+            Commands.deadline(Commands.waitSeconds(.3), m_drivetrain.cardinalMovement(-.25, 0)))
+        .andThen(m_elevator.setCoralPosition(CoralLevels.TRAVEL));
   }
 
   public Command coralPivotAndOutake(CoralLevels level) {
@@ -185,7 +188,10 @@ public class CommandFactory {
     return m_coralRollers
         .rollOutCommand(level)
         .andThen(Commands.waitSeconds(0.1))
-        .andThen(m_coralPivot.goToUpperSetpoint());
+        .andThen(m_coralPivot.goToUpperSetpoint())
+        .andThen(
+            Commands.deadline(Commands.waitSeconds(.3), m_drivetrain.cardinalMovement(-.25, 0)))
+        .andThen(m_elevator.setCoralPosition(CoralLevels.L2));
   }
 
   public Command zeroRobot() {


### PR DESCRIPTION
## Description of Changes
Add ability to backup on coral placement and coral intake from station to.

## Checklist:
<!--Put an 'x' in all of the boxes to assure following guidance.-->
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have [squashed related commits][1]

[1]: http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
